### PR TITLE
Removed alpha label

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@ SynchronizeFX is a library for **JavaFX 2 and later** that enables property bind
 
 It's build for applications that need realtime synchronization of the UI or other data.
 
-At the moment it's in an early alpha state.
-
 ## Authors
 SynchronizeFX is developed by [Saxonia Systems AG](https://github.com/saxsys). The main developer is [Raik Bieniek](https://github.com/rbi) . Contributors are [Alexander Casall](https://github.com/sialcasa), [Manuel Mauky](https://github.com/lestard) and Michael Thiele.
 


### PR DESCRIPTION
As the library is in productive use for some years by now without problems I think it's ok to not call it "alpha" anymore